### PR TITLE
add a error function for the dummy connection

### DIFF
--- a/mariadb_sqlbuilder/helpful/connection_dummy.py
+++ b/mariadb_sqlbuilder/helpful/connection_dummy.py
@@ -13,4 +13,5 @@ class Connect:
     def table(self, name: str) -> TableBuilder:
         return TableBuilder(self, name)
 
-
+    def get_available_cursor(self):
+        raise NotImplementedError("This function is only available with a active connection")


### PR DESCRIPTION
Add the get_available_cursor in the dummy function. So that when you use it you get a better error and know better what is going on.